### PR TITLE
MMA-5184 CPanel plugin generates error page without web style

### DIFF
--- a/application/controllers/DomainController.php
+++ b/application/controllers/DomainController.php
@@ -118,11 +118,7 @@ class DomainController extends Zend_Controller_Action
 		$this->view->headTitle()->set($brandname);
 		$this->view->headTitle()->setSeparator(' | ');
 
-        // paper lantern uses his own bootstrap.
-        if (strpos($_SERVER['PHP_SELF'], '/paper_lantern/') === false){
-            $this->view->headStyle()->appendStyle( file_get_contents(BASE_PATH . DS . 'public' . DS . 'css' . DS . 'bootstrap.min.css') );
-        }
-
+        $this->view->headStyle()->appendStyle( file_get_contents(BASE_PATH . DS . 'public' . DS . 'css' . DS . 'bootstrap.min.css') );
 		$this->view->headStyle()->appendStyle( file_get_contents(BASE_PATH . DS . 'public' . DS . 'css' . DS . 'bootstrap-responsive.min.css') );
 		$this->view->headStyle()->appendStyle( file_get_contents(BASE_PATH . DS . 'public' . DS . 'css' . DS . 'addon.css') );
 		$this->view->headScript()->appendScript( file_get_contents(BASE_PATH . DS . 'public' . DS . 'js' . DS . 'jquery.min.js') );

--- a/application/controllers/DomainController.php
+++ b/application/controllers/DomainController.php
@@ -118,7 +118,7 @@ class DomainController extends Zend_Controller_Action
 		$this->view->headTitle()->set($brandname);
 		$this->view->headTitle()->setSeparator(' | ');
 
-        $this->view->headStyle()->appendStyle( file_get_contents(BASE_PATH . DS . 'public' . DS . 'css' . DS . 'bootstrap.min.css') );
+		$this->view->headStyle()->appendStyle( file_get_contents(BASE_PATH . DS . 'public' . DS . 'css' . DS . 'bootstrap.min.css') );
 		$this->view->headStyle()->appendStyle( file_get_contents(BASE_PATH . DS . 'public' . DS . 'css' . DS . 'bootstrap-responsive.min.css') );
 		$this->view->headStyle()->appendStyle( file_get_contents(BASE_PATH . DS . 'public' . DS . 'css' . DS . 'addon.css') );
 		$this->view->headScript()->appendScript( file_get_contents(BASE_PATH . DS . 'public' . DS . 'js' . DS . 'jquery.min.js') );


### PR DESCRIPTION
Paper lantern was supposed to use a different bootstrap, but now it seems that we have an error for that. So we switched back to using the default for it, too.

https://nable-jira.solarwinds.com/browse/MMA-5184