### PR TITLE
Update bulkprotect.php

### DIFF
--- a/bin/bulkprotect.php
+++ b/bin/bulkprotect.php
@@ -15,6 +15,7 @@ require_once dirname(__FILE__) . '/../application/bootstrap.php';
 
 set_time_limit(0);
 ignore_user_abort(0);
+error_reporting(0);
 
 /** @var SpamFilter_Logger $logger */
 $logger = Zend_Registry::get('logger');


### PR DESCRIPTION
Added error_reporting(0) as we had a scenario where /root/error_log was filling rapidly with the following deprecation notices...

[24-Mar-2022 04:07:14 UTC] PHP Deprecated:  array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead in /usr/local/prospamfilter/library/Cpanel/Core/Object.php on line 112