### PR TITLE
MMA-9976 Add workaround for removeMXRecords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
+.nvim/
 tests/_output/failed
 sftp-config.json


### PR DESCRIPTION
It seems that there are cases when the line numbers reported by the
`listmxs` api change after removing an MX record, so re-run it before
each `removezonerecord` to make sure the line number is up to date.